### PR TITLE
Fixed errors I had when validating with validator.w3.org/feed

### DIFF
--- a/extensions/EFeed/EFeed.php
+++ b/extensions/EFeed/EFeed.php
@@ -311,8 +311,7 @@ class EFeed extends CComponent{
 		{
 			$head .= CHtml::openTag('rss',array(
 						"version"=>"2.0",
-						"xmlns:content"=>"http://purl.org/rss/1.0/modules/content/",
-						"xmlns:wfw"=>"http://wellformedweb.org/CommentAPI/")).PHP_EOL;	
+						"xmlns:atom"=>"http://www.w3.org/2005/Atom")).PHP_EOL;	
 		}    
 		elseif($this->type == self::RSS1)
 		{
@@ -379,6 +378,13 @@ class EFeed extends CComponent{
 				echo $this->makeNode($key,'',array('href'=>$value));
 				// And add the id for ATOM
 				echo $this->makeNode('id',$this->uuid($value,'urn:uuid:'));
+			}
+			elseif($key == 'atom:link'){
+				echo CHtml::tag('atom:link', array(
+					'href' => $value,
+					'rel' => 'self',
+					'type' => 'application/rss+xml',
+				));
 			}
 			else
 			{


### PR DESCRIPTION
Hi,

I fixed two errors that came up after I tried to validate my RSS2 XML with the [w3 feed validator](http://validator.w3.org/feed/). It's explained [here](http://feed2.w3.org/docs/warning/MissingAtomSelfLink.html).

FYI: I couldn't use the existing makeNode method because this tag has no content.

Thank you!
hofrob
