### PR TITLE
Conditional for css in EAssetManagerBoost

### DIFF
--- a/extensions/EScriptBoost/EAssetManagerBoost.php
+++ b/extensions/EScriptBoost/EAssetManagerBoost.php
@@ -164,7 +164,7 @@ class EAssetManagerBoost extends CAssetManager {
 					$dstFile, EScriptBoost::minifyJs(@file_get_contents($src), EScriptBoost::JS_MIN_PLUS));
 			@touch($dstFile, @filemtime($src));
 		} 
-		else if ($ext == 'CSS')
+		else if (($ext == 'CSS' && !$this->strpos_arr($dstFile, $this->minifiedExtensionFlags)) || $this->forceCompress )
 		{
 
 			Yii::trace('copyFile CSS Compressing: ' . $src, 'EAssetManagerBoost');


### PR DESCRIPTION
Added conditional to have css compression behave as javascript if extension exists in minifiedExtensionFlags or forceCompress is enabled
