### PR TITLE
Fixed error with Yii::t

### DIFF
--- a/extensions/EGMap/EGMap.php
+++ b/extensions/EGMap/EGMap.php
@@ -398,7 +398,7 @@ class EGMap extends EGMapBase {
 	public function appendMapTo($id)
 	{
 		if (substr(ltrim($id), 0, 1) != '#' && $id != 'body')
-			throw new CException(Yii::t('EGMap', 'The id of the layer doesnt seem a correct ID (not CSS selector) <br/>Function: ' . __FUNCTION__));
+			throw new CException(Yii::t('EGMap', 'The id of the layer doesnt seem a correct ID (not CSS selector) <br/>Function: {function}', array('{function}'=>__FUNCTION__)));
 		$this->_appendTo = $id;
 	}
 


### PR DESCRIPTION
I have fixed a php parse error when scanning the yii-messages;

$ ./yiic message config/message.php
...
Extracting messages from /srv/www/site/protected/extensions/EGMap/EGMap.php...

PHP Parse error:  syntax error, unexpected ')' in /srv/www/yii-1.1.10.r3566/framework/cli/commands/MessageCommand.php(133) : eval()'d code on line 1
...
