### PR TITLE
EConditionalValidator no longer clears existing object errors

### DIFF
--- a/validators/EConditionalValidator/EConditionalValidator.php
+++ b/validators/EConditionalValidator/EConditionalValidator.php
@@ -112,10 +112,20 @@ class EConditionalValidator extends CValidator {
 
 			$validator = CValidator::createValidator($conditionalValidator, $object, $attributes, $parameters);
 
+			# Backup and clear original errors
+			$errors = $object->getErrors();
+			$object->clearErrors();
+
+			# Execute conditionalValidator
 			$validator->validate($object);
-			if ($object->hasErrors())
+			$invalid = $object->hasErrors();
+
+			# Restore original errors
+			$object->clearErrors();
+			$object->addErrors($errors);
+
+			if ($invalid)
 			{
-				$object->clearErrors();
 				return false;
 			}
 		}


### PR DESCRIPTION
EConditionalValidator worked by running ConditionalValidators against the object and checking the errors. However, conditions always failed when there were already existing errors, and it would also remove existing errors after failing. This patch properly validates conditional rules when other errors exist, and doesn't clear existing errors.
